### PR TITLE
Potential fix for code scanning alert no. 3: Cross-window communication with unrestricted target origin

### DIFF
--- a/src/background/service/keyring/eth-ledger-bridge-keyring.ts
+++ b/src/background/service/keyring/eth-ledger-bridge-keyring.ts
@@ -871,12 +871,13 @@ class LedgerBridgeKeyring extends EventEmitter {
 
   _sendMessage(msg, cb) {
     msg.target = 'LEDGER-IFRAME';
+    const targetOrigin = this._getOrigin();
     if (!this.iframeLoaded) {
       this.msgQueue.push(() => {
-        this.iframe?.contentWindow?.postMessage(msg, '*');
+        this.iframe?.contentWindow?.postMessage(msg, targetOrigin);
       });
     } else {
-      this.iframe?.contentWindow?.postMessage(msg, '*');
+      this.iframe?.contentWindow?.postMessage(msg, targetOrigin);
     }
     const eventListener = ({ origin, data }) => {
       if (origin !== this._getOrigin()) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/tenderly-rabby-transaction-preview/security/code-scanning/3](https://github.com/Dargon789/tenderly-rabby-transaction-preview/security/code-scanning/3)

Use a strict target origin instead of `'*'` in `_sendMessage`.  
Best fix: compute `const targetOrigin = this._getOrigin();` once in `_sendMessage` and use it for both `postMessage` calls (queued and immediate). This preserves current behavior (same recipient iframe, same message format) while preventing cross-origin delivery.

**File/region to edit:**  
- `src/background/service/keyring/eth-ledger-bridge-keyring.ts`
- Method `_sendMessage(msg, cb)` around lines 872–880.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace wildcard postMessage target origin with a computed specific origin for both queued and immediate iframe messages in the Ledger bridge keyring.